### PR TITLE
[INTO-541] Upgrade pgbouncer version 1.17.0 to new version related to incorrect db name bug

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -106,8 +106,12 @@ static bool send_client_authreq(PgSocket *client)
 		return false;
 	}
 
-	if (!res)
+	if (!res) {
+	    slog_noise(client, "No authentication response received");
 		disconnect_client(client, false, "failed to send auth req");
+	} else {
+		slog_noise(client, "Auth request sent successfully");
+	}
 	return res;
 }
 
@@ -804,7 +808,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 					return false;
 				if (scram_client_final(client, length, data)) {
 					/* save SCRAM keys for user */
-					if (!client->scram_state.adhoc) {
+					if (!client->scram_state.adhoc && !client->db->fake) {
 						memcpy(client->pool->user->scram_ClientKey,
 						       client->scram_state.ClientKey,
 						       sizeof(client->scram_state.ClientKey));

--- a/test/test.sh
+++ b/test/test.sh
@@ -1272,6 +1272,50 @@ test_no_database_auth_user() {
 	return 0
 }
 
+test_no_database_md5_auth_scram_pw_success() {
+	# Testing what happens on successful SCRAM auth connection to non-existent DB
+	# Segfaults have been seen after mock authentication was put in place
+	# with md5 auth and a scram PW when saving SCRAM credentials. Including this test to check for the
+	# condition repeating.
+	
+	$have_getpeereid || return 77
+
+	admin "set auth_type='md5'"
+	PGPASSWORD=foo psql -X -U scramuser1 -d nosuchdb1 -c "select 1" && return 1
+	grep -F "no such database: nosuchdb1" $BOUNCER_LOG || return 1
+
+    return 0
+}
+
+test_no_database_scram_auth_scram_pw_success() {
+	# Testing what happens on successful SCRAM auth with a SCRAM PW connection to non-existent DB
+	# Segfaults have been seen after mock authentication was put in place
+	# with md5 auth and a scram PW. Including this test for completeness
+
+	$have_getpeereid || return 77
+
+	admin "set auth_type='scram-sha-256'"
+	PGPASSWORD=foo psql -X -U scramuser1 -d nosuchdb1 -c "select 1" && return 1
+	grep -F "no such database: nosuchdb1" $BOUNCER_LOG || return 1
+
+    return 0
+}
+
+test_no_database_md5_auth_md5_pw_success() {
+	# Testing what happens on successful MD5 auth with a MD5 pw connection to non-existent DB
+	# Segfaults have been seen after mock authentication was put in place
+	# with md5 auth and a scram PW. Including this test for completeness
+
+	$have_getpeereid || return 77
+
+	admin "set auth_type='md5'"
+	PGPASSWORD=foo psql -X -U muser1 -d nosuchdb1 -c "select 1" && return 1
+	grep -F "no such database: nosuchdb1" $BOUNCER_LOG || return 1
+
+    return 0
+}
+
+
 test_cancel() {
 	case `uname` in MINGW*) return 77;; esac
 
@@ -1442,6 +1486,9 @@ test_auto_database
 test_no_database
 test_no_database_authfail
 test_no_database_auth_user
+test_no_database_md5_auth_scram_pw_success
+test_no_database_scram_auth_scram_pw_success
+test_no_database_md5_auth_md5_pw_success
 test_cancel
 test_cancel_wait
 test_cancel_pool_size


### PR DESCRIPTION
Jira link: https://juloprojects.atlassian.net/browse/INTO-541

+ Problems: when connecting to non-existent DB with Scram Authentication, the pgbouncer service will be crashed. This is the bug from pgboucer 1.17.0

+ Objective: prevent the pgbouncer service will be crashed when connecting to non-exsistent DB with Scram Authentication